### PR TITLE
extends capabilities for cloudformation stack create and update

### DIFF
--- a/build.py
+++ b/build.py
@@ -19,7 +19,7 @@ description = "cfn-sphere - A CLI tool intended to simplify AWS CloudFormation h
 license = 'APACHE LICENSE, VERSION 2.0'
 summary = 'cfn-sphere AWS CloudFormation management cli'
 url = 'https://github.com/cfn-sphere/cfn-sphere'
-version = '1.1.2'
+version = '1.1.3'
 
 default_task = ['clean', 'analyze', 'package']
 

--- a/src/main/python/cfn_sphere/aws/cfn.py
+++ b/src/main/python/cfn_sphere/aws/cfn.py
@@ -280,7 +280,8 @@ class CloudFormation(object):
             "Parameters": stack.get_parameters_list(),
             "Capabilities": [
                 'CAPABILITY_IAM',
-                'CAPABILITY_NAMED_IAM'
+                'CAPABILITY_NAMED_IAM',
+                'CAPABILITY_AUTO_EXPAND'
             ],
             "Tags": stack.get_tags_list()
         }
@@ -310,7 +311,8 @@ class CloudFormation(object):
             "Parameters": stack.get_parameters_list(),
             "Capabilities": [
                 'CAPABILITY_IAM',
-                'CAPABILITY_NAMED_IAM'
+                'CAPABILITY_NAMED_IAM',
+                'CAPABILITY_AUTO_EXPAND'
             ],
             "Tags": stack.get_tags_list()
         }

--- a/src/unittest/python/aws_tests/cfn_tests.py
+++ b/src/unittest/python/aws_tests/cfn_tests.py
@@ -243,7 +243,7 @@ class CloudFormationApiTests(TestCase):
         cfn.create_stack(stack)
 
         cloudformation_mock.return_value.create_stack.assert_called_once_with(
-            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
             Parameters=[('a', 'b')],
             StackName='stack-name',
             Tags=[('any-tag', 'any-tag-value')],
@@ -272,7 +272,7 @@ class CloudFormationApiTests(TestCase):
         cfn.create_stack(stack)
 
         cloudformation_mock.return_value.create_stack.assert_called_once_with(
-            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
             Parameters=[('a', 'b')],
             StackName='stack-name',
             Tags=[('any-tag', 'any-tag-value')],
@@ -302,7 +302,7 @@ class CloudFormationApiTests(TestCase):
         cfn.create_stack(stack)
 
         cloudformation_mock.return_value.create_stack.assert_called_once_with(
-            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
             Parameters=[('a', 'b')],
             StackName='stack-name',
             Tags=[('any-tag', 'any-tag-value')],
@@ -332,7 +332,7 @@ class CloudFormationApiTests(TestCase):
         cfn.create_stack(stack)
 
         cloudformation_mock.return_value.create_stack.assert_called_once_with(
-            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
             OnFailure='DO_NOTHING',
             Parameters=[('a', 'b')],
             StackName='stack-name',
@@ -363,7 +363,7 @@ class CloudFormationApiTests(TestCase):
         cfn.create_stack(stack)
 
         cloudformation_mock.return_value.create_stack.assert_called_once_with(
-            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
             OnFailure='DO_NOTHING',
             DisableRollback=True,
             Parameters=[('a', 'b')],
@@ -412,7 +412,7 @@ class CloudFormationApiTests(TestCase):
         cfn.update_stack(stack)
 
         cloudformation_mock.return_value.update_stack.assert_called_once_with(
-            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
             Parameters=[('a', 'b')],
             StackName='stack-name',
             Tags=[('any-tag', 'any-tag-value')],
@@ -438,7 +438,7 @@ class CloudFormationApiTests(TestCase):
         cfn.update_stack(stack)
 
         cloudformation_mock.return_value.update_stack.assert_called_once_with(
-            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
             Parameters=[('a', 'b')],
             StackName='stack-name',
             Tags=[('any-tag', 'any-tag-value')],
@@ -465,7 +465,7 @@ class CloudFormationApiTests(TestCase):
         cfn.update_stack(stack)
 
         cloudformation_mock.return_value.update_stack.assert_called_once_with(
-            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'],
+            Capabilities=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM', 'CAPABILITY_AUTO_EXPAND'],
             Parameters=[('a', 'b')],
             StackName='stack-name',
             Tags=[('any-tag', 'any-tag-value')],


### PR DESCRIPTION
Context: Fixes -> An error occurred (InsufficientCapabilitiesException) when calling the UpdateStack operation: Requires capabilities : [CAPABILITY_AUTO_EXPAND]